### PR TITLE
passage vers ngx-matomo pour eventuel tracking d'events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8996,6 +8996,11 @@
         "tslib": "^1.9.0"
       }
     },
+    "ngx-matomo": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/ngx-matomo/-/ngx-matomo-0.1.4.tgz",
+      "integrity": "sha512-AKZMnJGyytZqAxuSh+k/AulyQhgqlnnsmtkfvHMJyNuh5g+wVpIbwac36RyeFU3El6INgZVso2CCLElV3bQnBQ=="
+    },
     "ngx-ui-loader": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/ngx-ui-loader/-/ngx-ui-loader-8.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "express": "^4.17.1",
     "moment": "^2.24.0",
     "ngx-hotjar": "0.0.5",
+    "ngx-matomo": "^0.1.4",
     "ngx-ui-loader": "^8.0.0",
     "path": "^0.12.7",
     "rxjs": "~6.4.0",

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { Meta, Title } from '@angular/platform-browser';
 import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
 import { filter, map, mergeMap } from 'rxjs/operators';
+import { MatomoTracker, MatomoInjector } from 'ngx-matomo';
 import * as globals from './globals';
 
 @Component({
@@ -16,12 +17,16 @@ export class AppComponent implements OnInit {
     private router: Router,
     private activatedRoute: ActivatedRoute,
     private titleService: Title,
-    private meta: Meta
+    private meta: Meta,
+    private matomoInjector: MatomoInjector,
+    private matomoTracker: MatomoTracker
   ) {
     const metaTag = this.meta.getTag('name=andi_id');
     if (metaTag) {
       globals.setSessionId(metaTag.content);
     }
+    this.matomoTracker.setUserId(globals.SessionId);
+    this.matomoInjector.init('http://stats.data.gouv.fr/', 94);
   }
   /* tslint:disable:no-string-literal */
   ngOnInit() {

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -5,6 +5,10 @@ import { AppComponent } from './app.component';
 import { CoreModule } from './core/core.module';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { NgxHotjarModule } from 'ngx-hotjar';
+import { MatomoModule } from 'ngx-matomo';
+
+// documentation matomo ngx https://www.npmjs.com/package/ngx-matomo
+// documentation hotjar ngx https://www.npmjs.com/package/ngx-hotjar
 
 @NgModule({
   declarations: [
@@ -15,7 +19,8 @@ import { NgxHotjarModule } from 'ngx-hotjar';
     AppRoutingModule,
     CoreModule,
     BrowserAnimationsModule,
-    NgxHotjarModule.forRoot('1404590')
+    NgxHotjarModule.forRoot('1404590'),
+    MatomoModule
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/src/app/core/services/tracking.service.ts
+++ b/src/app/core/services/tracking.service.ts
@@ -1,10 +1,8 @@
 import { Injectable } from '@angular/core';
 import { TrackingResponse } from 'src/models/tracking-response.model';
 import { HttpClient } from '@angular/common/http';
-import {
-  TrackingRequest,
-  StepContext
-} from 'src/models/tracking-request.model';
+import { MatomoTracker } from 'ngx-matomo';
+import { TrackingRequest, StepContext } from 'src/models/tracking-request.model';
 import * as moment from 'moment';
 
 import * as globals from '../../globals';
@@ -15,9 +13,15 @@ import * as globals from '../../globals';
 export class TrackingService {
   order = 0;
 
-  constructor(private http: HttpClient) {}
+  constructor(
+    private http: HttpClient,
+    private matomoTracker: MatomoTracker
+    ) {}
 
   track(page: string, action: StepContext, meta: string) {
+    // matomo tracker event example
+    // this.matomoTracker.trackEvent('category', 'action', 'name', someVal);
+
     return this.http.post(
       'https://andi.beta.gouv.fr/api/track',
       this.computeRequestBody(page, action, meta)

--- a/src/index.html
+++ b/src/index.html
@@ -27,9 +27,9 @@
     // add to meta
     document.querySelector('meta[name="andi_id"]').setAttribute("content", SESSION_ID);
 
+    /* obsoleted by matomo-ngx
     var _paq = window._paq || [];
     _paq.push(['setCustomVariable', 1, "SessionId", SESSION_ID, "visit" ]);
-    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
     _paq.push(["disableCookies"]);
     _paq.push(['trackPageView']);
     _paq.push(['enableLinkTracking']);
@@ -40,6 +40,7 @@
       var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
       g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
     })();
+    */
   </script>
   <!-- End Matomo Code -->
 


### PR DESCRIPTION
- tracking matomo pur angular (ngx)
- du coup le script JS est désactivé, ce qui rend la gestion du sessionId redondante: on corrigera par la suite
- il est désormais possible de tagger sur matomo, depuis le service tracking